### PR TITLE
:bug: Fix Google Books result selection

### DIFF
--- a/src/google-books.spec.ts
+++ b/src/google-books.spec.ts
@@ -1,0 +1,43 @@
+import { Book, selectBestBook } from "./google-books";
+
+const makeBook = (title: string, ratingsCount: number): Book => ({
+  kind: "books#volume",
+  id: title.toLowerCase().replace(/\s+/g, "-"),
+  volumeInfo: {
+    title,
+    authors: ["Example Author"],
+    publisher: "Example Publisher",
+    publishedDate: "2024-01-01",
+    description: `${title} description`,
+    industryIdentifiers: [
+      { type: "ISBN_13", identifier: "9780000000000" },
+      { type: "ISBN_10", identifier: "0000000000" },
+    ],
+    pageCount: 123,
+    printType: "BOOK",
+    categories: ["Computers"],
+    averageRating: 4,
+    ratingsCount,
+    maturityRating: "NOT_MATURE",
+    imageLinks: {
+      thumbnail: `https://example.com/${encodeURIComponent(title)}.jpg`,
+    },
+    language: "en",
+    previewLink: `https://example.com/${encodeURIComponent(title)}/preview`,
+    infoLink: `https://example.com/${encodeURIComponent(title)}/info`,
+    canonicalVolumeLink: `https://example.com/${encodeURIComponent(title)}`,
+  },
+});
+
+describe("selectBestBook", () => {
+  it("keeps Google Books relevance order instead of sorting by popularity", () => {
+    const relevantResult = makeBook("Operating Systems: Three Easy Pieces", 12);
+    const morePopularButLessRelevantResult = makeBook("Operating System Concepts", 275);
+
+    expect(selectBestBook([relevantResult, morePopularButLessRelevantResult])).toBe(relevantResult);
+  });
+
+  it("throws when Google Books returns no items", () => {
+    expect(() => selectBestBook([])).toThrow("Book not found");
+  });
+});

--- a/src/google-books.ts
+++ b/src/google-books.ts
@@ -57,6 +57,15 @@ export interface BookResult {
   };
 }
 
+export const selectBestBook = (items: Book[]): Book => {
+  if (!items.length) throw new Error("Book not found");
+
+  // Google Books already returns results in relevance order for the query. Sorting
+  // by popularity can pick a more-reviewed but less-relevant book with a similar
+  // title, which is surprising when the API's first result is the exact match.
+  return items[0];
+};
+
 export const search = async (q: string): Promise<BookResult> => {
   const results = await got<{
     items: Book[];
@@ -67,9 +76,7 @@ export const search = async (q: string): Promise<BookResult> => {
     console.error("No results.body.items", JSON.stringify(results.body));
     throw new Error("Book not found");
   }
-  const result = results.body.items.sort(
-    (a, b) => (Number(b.volumeInfo.ratingsCount) || 0) - (Number(a.volumeInfo.ratingsCount) || 0)
-  )[0];
+  const result = selectBestBook(results.body.items);
 
   return {
     title: result.volumeInfo.title,


### PR DESCRIPTION
## Summary
- Fixes Google Books result selection by preserving the API's relevance order instead of sorting results by rating count.
- Extracts the selection rule into `selectBestBook()` so it can be regression-tested.
- Adds a Jest regression test covering the relevance-vs-popularity case from #133.

Fixes #133

## Test Plan
- `npm run build`
- `npm test`
- `npm run package`

## Notes
- #131 is still a separate intermittent Google Books 429/rate-limit issue; this PR only fixes the incorrect-result selection bug.
