### PR TITLE
:bug: Pin gitmojis for release tooling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3693,11 +3693,6 @@
         "git-up": "^7.0.0"
       }
     },
-    "node_modules/gitmojis": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/gitmojis/-/gitmojis-3.13.3.tgz",
-      "integrity": "sha512-s0x6Kw6ipfBzDImDxOoSbwn82c+xlPBDBMYaYmtp+fC2fKk/i9OG1nORra0Wz0Lh37VgpCR4ZPLyJZsgRUZEng=="
-    },
     "node_modules/glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
@@ -11721,6 +11716,11 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
     },
+    "node_modules/semantic-release-gitmoji/node_modules/gitmojis": {
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/gitmojis/-/gitmojis-3.13.2.tgz",
+      "integrity": "sha512-LqtmY8cectRus+1/hoXotA/ln0Fgjxwn/SUSzvZdYtkArvzrTEfACIU6bWC1Jw/wezYHIIzZdJbJhePKcYKzpw=="
+    },
     "node_modules/semantic-release/node_modules/@octokit/auth-token": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.1.tgz",
@@ -18330,11 +18330,6 @@
       "requires": {
         "git-up": "^7.0.0"
       }
-    },
-    "gitmojis": {
-      "version": "3.13.3",
-      "resolved": "https://registry.npmjs.org/gitmojis/-/gitmojis-3.13.3.tgz",
-      "integrity": "sha512-s0x6Kw6ipfBzDImDxOoSbwn82c+xlPBDBMYaYmtp+fC2fKk/i9OG1nORra0Wz0Lh37VgpCR4ZPLyJZsgRUZEng=="
     },
     "glob": {
       "version": "7.1.6",
@@ -26110,7 +26105,7 @@
         "debug": "^4.3.2",
         "emoji-regex": "^9.2.2",
         "git-url-parse": "^13.0.0",
-        "gitmojis": "^3.13.1",
+        "gitmojis": "3.13.2",
         "handlebars": "^4.7.6",
         "issue-regex": "^3.1.0",
         "lodash.clonedeep": "^4.5.0",
@@ -26123,6 +26118,11 @@
           "version": "9.2.2",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
           "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="
+        },
+        "gitmojis": {
+          "version": "3.13.2",
+          "resolved": "https://registry.npmjs.org/gitmojis/-/gitmojis-3.13.2.tgz",
+          "integrity": "sha512-LqtmY8cectRus+1/hoXotA/ln0Fgjxwn/SUSzvZdYtkArvzrTEfACIU6bWC1Jw/wezYHIIzZdJbJhePKcYKzpw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -54,5 +54,8 @@
     "prettier": "^2.7.1",
     "randomcolor": "^0.6.2",
     "shelljs": "^0.8.5"
+  },
+  "overrides": {
+    "gitmojis": "3.13.2"
   }
 }


### PR DESCRIPTION
## Summary
- Pins `gitmojis` to the last CommonJS-compatible 3.13.2 release via npm overrides
- Updates the lockfile so `semantic-release-gitmoji` can load during Release CI
- Follow-up to the failed Release CI run after #136: https://github.com/AnandChowdhary/bookshelf-action/actions/runs/28226530495

## Test Plan
- `/tmp/node-v18.20.8-linux-x64/bin/npm ci`
- `/tmp/node-v18.20.8-linux-x64/bin/npm run build`
- `/tmp/node-v18.20.8-linux-x64/bin/npm test -- --runInBand`
- `/tmp/node-v18.20.8-linux-x64/bin/npm run package`
- `/tmp/node-v18.20.8-linux-x64/bin/node -e "require('semantic-release-gitmoji/lib/helper/parse-commits')"`
- `npx semantic-release --dry-run --no-ci` loads `semantic-release-gitmoji` plugins successfully on the branch
